### PR TITLE
Add missing dep (pauls-dat-api)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bin": "bin.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/datproject/dat-pin.git"
+    "url": "git+https://github.com/datproject/dat-store.git"
   },
   "keywords": [
     "dat",
@@ -22,9 +22,9 @@
   "author": "rangermauve",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/datproject/dat-pin/issues"
+    "url": "https://github.com/datproject/dat-store/issues"
   },
-  "homepage": "https://github.com/datproject/dat-pin#readme",
+  "homepage": "https://github.com/datproject/dat-store#readme",
   "dependencies": {
     "dat-librarian": "^1.1.4-alpha",
     "dat-pinning-service-client": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "fastify-websocket": "^0.3.0",
     "fs-extra": "^7.0.1",
     "os-service": "^2.1.3",
+    "pauls-dat-api": "^8.1.0",
     "read": "^1.0.7",
     "userhome": "^1.0.0",
     "yargs": "^13.2.2"


### PR DESCRIPTION
Note that there's a [Regular Expression Denial of Service advisory in braces](https://npmjs.com/advisories/786) (pauls-dat-api > anymatch > micromatch > braces).
