### PR TITLE
Store improvements - 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ This project makes use of the [env-paths](https://github.com/sindresorhus/env-pa
 
 The config file is stored using the [conf](https://github.com/sindresorhus/conf) module, with the name `dat-store`. You can override the folder it'll be stored in with the `--config-location` flag.
 
-The store service is using the [data](https://github.com/sindresorhus/env-paths#pathsdata) directory, also with the name `dat-store`. You can override the folder the data will be stored at using the `--storage-location` flag.
+The store service is using the [data](https://github.com/sindresorhus/env-paths#pathsdata) directory, also with the name `dat-store`. You can override the folder the data will be stored at using the `--storage-location` flag. You can configure whether the store keeps track of just the latest changes, or the full history with the `--latest` flag. By default, it will store the entire history.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # dat-store
-An extension for the Dat CLI to support storage providers
+
+dat-store aims to solve the question of "How do I make sure my Dat is being shared".
+
+It can be used as an extension for the Dat CLI to add your Dats to "stores" that will keep a copy of your content and keep it online.
 
 ```shell
 npm install -g dat-store

--- a/README.md
+++ b/README.md
@@ -14,35 +14,51 @@ dat-store dat://0a9e202b8055721bd2bc93b3c9bbc03efdbda9cfee91f01a123fdeaadeba303e
 dat-store install-service
 
 # Configure external storage provider
-dat-store set-provider https://hashbase.io/
-dat-store login yourusername
+dat-store set-provider hashbase https://hashbase.io/
+dat-store login hashbase yourusername
+dat-store add hashbase dat://0a9e202b8055721bd2bc93b3c9bbc03efdbda9cfee91f01a123fdeaadeba303e/
 ```
 
 ## Commands
 
 ```
-dat-store <url>
+dat-store [provider] <url>
 
 Add a Dat to your storage provider.
 
 Commands:
-  dat-store add <url>                    Add a Dat to your storage provider.
+  dat-store add [provider] <url>           Add a Dat to your storage provider.
                                                                        [default]
-  dat-store remove <url>                 Remove a Dat from your storage
-                                         provider.
-  dat-store list                         List the Dats in your storage provider.
-  dat-store set-provider <url>           Set the URL of your storage provider.
-  dat-store get-provider                 Get the URL of your storage provider.
-  dat-store unset-provider               Reset your storage provider to the
-                                         default: http://localhost:3472
-  dat-store login <username> [password]  Logs you into your storage provider.
-  dat-store logout                       Logs you out of your storage provider.
-  dat-store run-service                  Runs a local storage provider.
-  dat-store install-service              Installs a storage service on your
-                                         machine. This will run in the
-                                         background while your computer is
-                                         active.
-  dat-store uninstall-service            Uninstalls your local storage service.
+  dat-store remove [provider] <url>        Remove a Dat from your storage
+                                           provider.
+  dat-store list [provider]                List the Dats in your storage
+                                           provider.
+  dat-store set-provider [provider] <url>  Set the URL of your storage provider.
+  dat-store get-provider [provider]        Get the URL of your storage provider.
+  dat-store unset-provider                 Reset your storage provider to the
+                                           default: http://localhost:3472
+  dat-store login <username> [password]    Logs you into your storage provider.
+  dat-store logout                         Logs you out of your storage
+                                           provider.
+  dat-store run-service                    Runs a local storage provider.
+  dat-store install-service                Installs a storage service on your
+                                           machine. This will run in the
+                                           background while your computer is
+                                           active.
+  dat-store uninstall-service              Uninstalls your local storage
+                                           service.
+
+Options:
+  --version           Show version number                              [boolean]
+  --help              Show help                                        [boolean]
+  --storage-location  The folder to store dats in
+  --port              The port to use for the HTTP API           [default: 3472]
+  --host              The hostname to make the HTTP server listen on
+  --verbose           Whether the HTTP server should output logs
+                                                       [boolean] [default: true]
+  --dat-port          The port to listen for P2P connections on  [default: 3282]
+  --latest            Whether to download just the latest changes
+                                                      [boolean] [default: false]
 ```
 
 ## How it works:
@@ -54,6 +70,7 @@ Commands:
 - Binds to port `3282` for interacting with the P2P network. This can be configured with the `--dat-port` CLI option.
 - The service uses [dat-librarian](https://www.npmjs.com/package/dat-librarian) to manage archives
 - The service acts as a discovery gateway for [discovery-swarm-stream](https://www.npmjs.com/package/discovery-swarm-stream)
+- Can work with multiple providers at the same time
 
 ## Where is stuff stored?
 
@@ -62,3 +79,7 @@ This project makes use of the [env-paths](https://github.com/sindresorhus/env-pa
 The config file is stored using the [conf](https://github.com/sindresorhus/conf) module, with the name `dat-store`. You can override the folder it'll be stored in with the `--config-location` flag.
 
 The store service is using the [data](https://github.com/sindresorhus/env-paths#pathsdata) directory, also with the name `dat-store`. You can override the folder the data will be stored at using the `--storage-location` flag. You can configure whether the store keeps track of just the latest changes, or the full history with the `--latest` flag. By default, it will store the entire history.
+
+## How do I deal with multiple stores?
+
+`dat-store` supports multiple remote stores using the optional `provider` CLI argument. Whenever you `add` `remove` or `list`, you can specify a provider argument to tell the CLI which store it should be talking to. Think of providers as being similar to [git remotes](https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes)

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Commands:
 
 - Uses [dat-pinning-service-client](https://github.com/beakerbrowser/dat-pinning-service-client) to talk to storage providers that adhere to [DEP 0003](https://www.datprotocol.com/deps/0003-http-pinning-service-api/)
 - Can start a local  called `dat-store` using `dat-store install-service` (uses [os-service](https://www.npmjs.com/package/os-service))
-- Runs on `http://localhost:3472`
-- Binds to port `3282` for interacting with the P2P network
+- Runs on `http://localhost:3472`. Configure port with `--port`, configure hostname / network interface with `--host`.
+- Server logs can be turned off using `--verbose false`
+- Binds to port `3282` for interacting with the P2P network. This can be configured with the `--dat-port` CLI option.
 - The service uses [dat-librarian](https://www.npmjs.com/package/dat-librarian) to manage archives
 - The service acts as a discovery gateway for [discovery-swarm-stream](https://www.npmjs.com/package/discovery-swarm-stream)
 

--- a/README.md
+++ b/README.md
@@ -53,3 +53,11 @@ Commands:
 - Binds to port `3282` for interacting with the P2P network
 - The service uses [dat-librarian](https://www.npmjs.com/package/dat-librarian) to manage archives
 - The service acts as a discovery gateway for [discovery-swarm-stream](https://www.npmjs.com/package/discovery-swarm-stream)
+
+## Where is stuff stored?
+
+This project makes use of the [env-paths](https://github.com/sindresorhus/env-paths#pathsconfig) module to determine the best place to store data based on the platform.
+
+The config file is stored using the [conf](https://github.com/sindresorhus/conf) module, with the name `dat-store`. You can override the folder it'll be stored in with the `--config-location` flag.
+
+The store service is using the [data](https://github.com/sindresorhus/env-paths#pathsdata) directory, also with the name `dat-store`. You can override the folder the data will be stored at using the `--storage-location` flag.

--- a/README.md
+++ b/README.md
@@ -86,3 +86,13 @@ The store service is using the [data](https://github.com/sindresorhus/env-paths#
 ## How do I deal with multiple stores?
 
 `dat-store` supports multiple remote stores using the optional `provider` CLI argument. Whenever you `add` `remove` or `list`, you can specify a provider argument to tell the CLI which store it should be talking to. Think of providers as being similar to [git remotes](https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes)
+
+## How do I add a folder?
+
+Depending on where a store is located, there are different ways that it can handle folders.
+
+For local stores, you when you specify a folder, it'll behave similarly to the [dat share](https://github.com/datproject/dat#sharing-data) command, but instead of needing to have the command running all the time, it'll be handled by the store. The store will load up the dat archive inside your folder, watch for changes, and share them with the rest of the network.
+
+For remote stores, it's a little different. Since a remote store is running on a different computer, it doesn't have a way to access your local folder. In that case, dat-store will find the Dat URL from inside the folder and will send it out to the store like it normally would.
+
+These two modes of operation can be combined together. When you create a dat, add it to your local store. Then add the URL to the remote store. This way, when you make a change to the folder, the local store will update the Dat, and the remote store will get the change and spread it to the rest of the network.

--- a/client.js
+++ b/client.js
@@ -1,5 +1,4 @@
 const util = require('util')
-const fs = require('fs-extra')
 const Conf = require('conf')
 
 const { DatPinningServiceClient } = require('dat-pinning-service-client')
@@ -9,35 +8,24 @@ const debug = require('debug')('dat-store:client')
 // URL for storage provider running on localhost
 const LOCAL_SERVICE = 'http://localhost:3472'
 
-const ERROR_NO_SERVICE = (service) => `Could not connect to service ${this.service}
+const ERROR_NO_SERVICE = (service) => `Could not connect to service ${service}
 Make sure you have a local service running with 'dat store install-service'
 Also check if the remote service you have configured is online`
+const ERROR_NO_PROVIDER = (provider) => `Provider URL not set for ${provider}`
 
 module.exports =
 
 class StoreClient {
-  constructor ({ configLocation }) {
+  constructor ({ configLocation, provider }) {
     const options = {}
+
+    this.provider = provider
 
     if (configLocation) {
       options.cwd = configLocation
     }
 
     this.config = new Conf(options)
-  }
-
-  async getConfig () {
-    let config = {
-      service: LOCAL_SERVICE,
-      token: null
-    }
-    try {
-      const rawConfig = await fs.readFile(this.configLocation, 'utf8')
-      config = JSON.parse(rawConfig)
-    } catch (e) {
-      debug(e)
-    }
-    return config
   }
 
   async updateConfig (data) {
@@ -50,23 +38,71 @@ class StoreClient {
     this.initialized = true
   }
 
-  async init () {
-    this.service = this.config.get('service', LOCAL_SERVICE)
-    this.token = this.config.get('token', null)
+  async getProviders () {
+    return this.getConfig('providers', {})
+  }
 
-    this.client = new DatPinningServiceClient(this.service)
+  async setProvider (provider, url) {
+    const providers = await this.getProviders()
+
+    const newProviders = Object.assign({}, providers, {
+      [provider]: url
+    })
+
+    await this.setConfig('providers', newProviders)
+  }
+
+  async getProviderURL (provider) {
+    const providers = await this.getProviders()
+
+    const url = providers[provider]
+
+    if (!url) throw new Error(ERROR_NO_PROVIDER(provider))
+
+    return url
+  }
+
+  async getService () {
+    if (this.provider) {
+      return this.getProviderURL(this.provider)
+    } else {
+      return this.getConfig('service', LOCAL_SERVICE)
+    }
+  }
+
+  async setService (service) {
+    if (this.provider) {
+      return this.setProvider(this.provider, service)
+    } else {
+      await this.setConfig('service', service)
+    }
+  }
+
+  async unsetService () {
+    await this.setService(LOCAL_SERVICE)
+  }
+
+  async getToken () {
+    return this.getConfig('token', null)
+  }
+
+  async setToken (token) {
+    await this.setConfig('token', token)
+  }
+
+  async init () {
+    const service = await this.getService()
+    this.client = new DatPinningServiceClient(service)
     try {
       await this.callClient('fetchPSADoc')
-      if (this.token) {
-        this.client.setSession(this.token)
+      const token = await this.getToken()
+      if (token) {
+        this.client.setSession(token)
       }
     } catch (e) {
       debug(e)
     }
-  }
-
-  ensureService () {
-    if (!this.client.psaDoc) throw new Error(ERROR_NO_SERVICE(this.service))
+    if (!this.client.psaDoc) throw new Error(ERROR_NO_SERVICE(service))
   }
 
   async callClient (method, ...args) {
@@ -75,66 +111,39 @@ class StoreClient {
 
   async login (username, password) {
     await this.ensureInit()
-    this.ensureService()
 
     await this.callClient('login', username, password)
     const token = this.client.sessionToken
-    await this.updateConfig({
-      token
-    })
+
+    await this.setToken(token)
   }
 
   async logout () {
-    await this.ensureInit()
-    this.ensureService()
-
-    await this.updateConfig({
-      token: null
-    })
+    await this.setToken(null)
   }
 
-  async setService (service) {
-    await this.ensureInit()
-
-    await this.updateConfig({
-      service
-    })
-
-    this.service = service
+  async getConfig (key, defaultValue) {
+    return this.config.get(key, defaultValue)
   }
 
-  async unsetService () {
-    await this.ensureInit()
-
-    await this.updateConfig({
-      service: LOCAL_SERVICE
-    })
-
-    this.service = LOCAL_SERVICE
-  }
-
-  async getService () {
-    await this.ensureInit()
-    return this.service
+  async setConfig (key, value) {
+    this.config.set(key, value)
   }
 
   async add (url) {
     await this.ensureInit()
-    this.ensureService()
 
     return this.callClient('addDat', { url })
   }
 
   async list () {
     await this.ensureInit()
-    this.ensureService()
 
     return this.callClient('listDats')
   }
 
   async remove (url) {
     await this.ensureInit()
-    this.ensureService()
 
     return this.callClient('removeDat', url)
   }

--- a/client.js
+++ b/client.js
@@ -12,6 +12,10 @@ const CONFIG_LOCATION = userhome('.dat', 'store.json')
 // URL for storage provider running on localhost
 const LOCAL_SERVICE = 'http://localhost:3472'
 
+const ERROR_NO_SERVICE = (service) => `Could not connect to service ${this.service}
+Make sure you have a local service running with 'dat store install-service'
+Also check if the remote service you have configured is online`
+
 module.exports =
 
 class StoreClient {
@@ -63,12 +67,17 @@ class StoreClient {
     }
   }
 
+  ensureService () {
+    if(!this.client.psaDoc) throw new Error(ERROR_NO_SERVICE(this.service))
+  }
+
   async callClient (method, ...args) {
     return util.promisify(this.client[method]).call(this.client, ...args)
   }
 
   async login (username, password) {
     await this.ensureInit()
+    this.ensureService()
 
     await this.callClient('login', username, password)
     const token = this.client.sessionToken
@@ -79,6 +88,7 @@ class StoreClient {
 
   async logout () {
     await this.ensureInit()
+    this.ensureService()
 
     await this.updateConfig({
       token: null
@@ -112,18 +122,21 @@ class StoreClient {
 
   async add (url) {
     await this.ensureInit()
+    this.ensureService()
 
     return this.callClient('addDat', { url })
   }
 
   async list () {
     await this.ensureInit()
+    this.ensureService()
 
     return this.callClient('listDats')
   }
 
   async remove (url) {
     await this.ensureInit()
+    this.ensureService()
 
     return this.callClient('removeDat', url)
   }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const addServiceOptions = (yargs) => yargs
   })
   .option('port', {
     describe: 'The port to use for the HTTP API',
-    default: 3282
+    default: 3472
   })
   .option('host', {
     describe: 'The hostname to make the HTTP server listen on'
@@ -19,7 +19,8 @@ const addServiceOptions = (yargs) => yargs
     type: 'boolean'
   })
   .option('dat-port', {
-    describe: 'The port to listen for P2P connections on'
+    describe: 'The port to listen for P2P connections on',
+    default: 3282
   })
   .option('latest', {
     describe: 'Whether to download just the latest changes',

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ const addServiceOptions = (yargs) => yargs
     describe: 'The folder to store dats in'
   })
   .option('port', {
-    describe: 'The port to use for the HTTP API'
+    describe: 'The port to use for the HTTP API',
+    default: 3282
   })
   .option('host', {
     describe: 'The hostname to make the HTTP server listen on'
@@ -19,6 +20,11 @@ const addServiceOptions = (yargs) => yargs
   })
   .option('dat-port', {
     describe: 'The port to listen for P2P connections on'
+  })
+  .option('latest', {
+    describe: 'Whether to download just the latest changes',
+    default: false,
+    type: 'boolean'
   })
 const addClientOptions = (yargs) => yargs
   .option('config-location')

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const addServiceOptions = (yargs) => yargs
   })
   .option('latest', {
     describe: 'Whether to download just the latest changes',
-    default: false,
+    default: false,041
     type: 'boolean'
   })
 const addClientOptions = (yargs) => yargs
@@ -33,11 +33,11 @@ const noOptions = () => void 0
 
 const commands = yargs
   .scriptName(SERVICE_NAME)
-  .command(['add <url>', '$0 <url>'], 'Add a Dat to your storage provider.', addServiceOptions, add)
-  .command('remove <url>', 'Remove a Dat from your storage provider.', addServiceOptions, remove)
-  .command('list', 'List the Dats in your storage provider.', addServiceOptions, list)
-  .command('set-provider <url>', 'Set the URL of your storage provider.', addServiceOptions, setService)
-  .command('get-provider', 'Get the URL of your storage provider.', addServiceOptions, getService)
+  .command(['add [provider] <url>', '$0 [provider] <url>'], 'Add a Dat to your storage provider.', addServiceOptions, add)
+  .command('remove [provider] <url>', 'Remove a Dat from your storage provider.', addServiceOptions, remove)
+  .command('list [provider] ', 'List the Dats in your storage provider.', addServiceOptions, list)
+  .command('set-provider [provider] <url>', 'Set the URL of your storage provider.', addServiceOptions, setService)
+  .command('get-provider [provider]', 'Get the URL of your storage provider.', addServiceOptions, getService)
   .command('unset-provider', 'Reset your storage provider to the default: http://localhost:3472', addServiceOptions, unsetService)
   .command('login <username> [password]', 'Logs you into your storage provider.', addServiceOptions, login)
   .command('logout', 'Logs you out of your storage provider.', addServiceOptions, logout)

--- a/index.js
+++ b/index.js
@@ -2,25 +2,23 @@ const yargs = require('yargs')
 
 const SERVICE_NAME = 'dat-store'
 
+const addStorageOption = (yargs) => yargs.option('storage-location')
+const addConfigLocation = (yargs) => yargs.option('config-location')
+const noOptions = () => void 0
+
 const commands = yargs
   .scriptName(SERVICE_NAME)
-  .command(['add <url>', '$0 <url>'], 'Add a Dat to your storage provider.', () => void 0, add)
-  .command('remove <url>', 'Remove a Dat from your storage provider.', () => void 0, remove)
-  .command('list', 'List the Dats in your storage provider.', () => void 0, list)
-  .command('set-provider <url>', 'Set the URL of your storage provider.', () => void 0, setService)
-  .command('get-provider', 'Get the URL of your storage provider.', () => void 0, getService)
-  .command('unset-provider', 'Reset your storage provider to the default: http://localhost:3472', () => void 0, unsetService)
-  .command('login <username> [password]', 'Logs you into your storage provider.', () => void 0, login)
-  .command('logout', 'Logs you out of your storage provider.', () => void 0, logout)
-  .command('run-service', 'Runs a local storage provider.', (yargs) => {
-    yargs
-      .option('storage-location')
-  }, runService)
-  .command('install-service', 'Installs a storage service on your machine. This will run in the background while your computer is active.', (yargs) => {
-    yargs
-      .option('storage-location')
-  }, installService)
-  .command('uninstall-service', 'Uninstalls your local storage service.', () => void 0, uninstallService)
+  .command(['add <url>', '$0 <url>'], 'Add a Dat to your storage provider.', addConfigLocation, add)
+  .command('remove <url>', 'Remove a Dat from your storage provider.', addConfigLocation, remove)
+  .command('list', 'List the Dats in your storage provider.', addConfigLocation, list)
+  .command('set-provider <url>', 'Set the URL of your storage provider.', addConfigLocation, setService)
+  .command('get-provider', 'Get the URL of your storage provider.', addConfigLocation, getService)
+  .command('unset-provider', 'Reset your storage provider to the default: http://localhost:3472', addConfigLocation, unsetService)
+  .command('login <username> [password]', 'Logs you into your storage provider.', addConfigLocation, login)
+  .command('logout', 'Logs you out of your storage provider.', addConfigLocation, logout)
+  .command('run-service', 'Runs a local storage provider.', addStorageOption, runService)
+  .command('install-service', 'Installs a storage service on your machine. This will run in the background while your computer is active.', addStorageOption, installService)
+  .command('uninstall-service', 'Uninstalls your local storage service.', noOptions, uninstallService)
   .help()
 
 module.exports = (argv) => {

--- a/index.js
+++ b/index.js
@@ -2,22 +2,22 @@ const yargs = require('yargs')
 
 const SERVICE_NAME = 'dat-store'
 
-const addStorageOption = (yargs) => yargs.option('storage-location')
-const addConfigLocation = (yargs) => yargs.option('config-location')
+const addClientOptions = (yargs) => yargs.option('storage-location')
+const addServiceOptions = (yargs) => yargs.option('config-location')
 const noOptions = () => void 0
 
 const commands = yargs
   .scriptName(SERVICE_NAME)
-  .command(['add <url>', '$0 <url>'], 'Add a Dat to your storage provider.', addConfigLocation, add)
-  .command('remove <url>', 'Remove a Dat from your storage provider.', addConfigLocation, remove)
-  .command('list', 'List the Dats in your storage provider.', addConfigLocation, list)
-  .command('set-provider <url>', 'Set the URL of your storage provider.', addConfigLocation, setService)
-  .command('get-provider', 'Get the URL of your storage provider.', addConfigLocation, getService)
-  .command('unset-provider', 'Reset your storage provider to the default: http://localhost:3472', addConfigLocation, unsetService)
-  .command('login <username> [password]', 'Logs you into your storage provider.', addConfigLocation, login)
-  .command('logout', 'Logs you out of your storage provider.', addConfigLocation, logout)
-  .command('run-service', 'Runs a local storage provider.', addStorageOption, runService)
-  .command('install-service', 'Installs a storage service on your machine. This will run in the background while your computer is active.', addStorageOption, installService)
+  .command(['add <url>', '$0 <url>'], 'Add a Dat to your storage provider.', addServiceOptions, add)
+  .command('remove <url>', 'Remove a Dat from your storage provider.', addServiceOptions, remove)
+  .command('list', 'List the Dats in your storage provider.', addServiceOptions, list)
+  .command('set-provider <url>', 'Set the URL of your storage provider.', addServiceOptions, setService)
+  .command('get-provider', 'Get the URL of your storage provider.', addServiceOptions, getService)
+  .command('unset-provider', 'Reset your storage provider to the default: http://localhost:3472', addServiceOptions, unsetService)
+  .command('login <username> [password]', 'Logs you into your storage provider.', addServiceOptions, login)
+  .command('logout', 'Logs you out of your storage provider.', addServiceOptions, logout)
+  .command('run-service', 'Runs a local storage provider.', addClientOptions, runService)
+  .command('install-service', 'Installs a storage service on your machine. This will run in the background while your computer is active.', addClientOptions, installService)
   .command('uninstall-service', 'Uninstalls your local storage service.', noOptions, uninstallService)
   .help()
 

--- a/index.js
+++ b/index.js
@@ -2,8 +2,26 @@ const yargs = require('yargs')
 
 const SERVICE_NAME = 'dat-store'
 
-const addClientOptions = (yargs) => yargs.option('storage-location')
-const addServiceOptions = (yargs) => yargs.option('config-location')
+const addServiceOptions = (yargs) => yargs
+  .option('storage-location', {
+    describe: 'The folder to store dats in'
+  })
+  .option('port', {
+    describe: 'The port to use for the HTTP API'
+  })
+  .option('host', {
+    describe: 'The hostname to make the HTTP server listen on'
+  })
+  .option('verbose', {
+    describe: 'Whether the HTTP server should output logs',
+    default: true,
+    type: 'boolean'
+  })
+  .option('dat-port', {
+    describe: 'The port to listen for P2P connections on'
+  })
+const addClientOptions = (yargs) => yargs
+  .option('config-location')
 const noOptions = () => void 0
 
 const commands = yargs
@@ -95,11 +113,7 @@ async function installService (args) {
   const service = require('os-service')
   const programPath = getServiceLocation()
 
-  const programArgs = []
-
-  if (args.storageLocation) {
-    programArgs.push('--storage-location', args.storageLocation)
-  }
+  const programArgs = process.argv.slice(3)
 
   service.add(SERVICE_NAME, { programPath, programArgs }, (e) => {
     if (e) throw e

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const addServiceOptions = (yargs) => yargs
   })
   .option('latest', {
     describe: 'Whether to download just the latest changes',
-    default: false,041
+    default: false,
     type: 'boolean'
   })
 const addClientOptions = (yargs) => yargs
@@ -33,8 +33,8 @@ const noOptions = () => void 0
 
 const commands = yargs
   .scriptName(SERVICE_NAME)
-  .command(['add [provider] <url>', '$0 [provider] <url>'], 'Add a Dat to your storage provider.', addServiceOptions, add)
-  .command('remove [provider] <url>', 'Remove a Dat from your storage provider.', addServiceOptions, remove)
+  .command(['add [provider] <url|path>', '$0 [provider] <url>'], 'Add a Dat to your storage provider.', addServiceOptions, add)
+  .command('remove [provider] <url|path>', 'Remove a Dat from your storage provider.', addServiceOptions, remove)
   .command('list [provider] ', 'List the Dats in your storage provider.', addServiceOptions, list)
   .command('set-provider [provider] <url>', 'Set the URL of your storage provider.', addServiceOptions, setService)
   .command('get-provider [provider]', 'Get the URL of your storage provider.', addServiceOptions, getService)

--- a/library.js
+++ b/library.js
@@ -1,0 +1,230 @@
+const fs = require('fs-extra')
+const path = require('path')
+const createDiscovery = require('hyperdiscovery')
+const Hyperdrive = require('hyperdrive')
+const DatEncoding = require('dat-encoding')
+const mirror = require('mirror-folder')
+const datIgnore = require('dat-ignore')
+const datDns = require('dat-dns')()
+
+const storage = require('./storage')
+
+const ERROR_NOT_FOUND_URL = (url) => `URL Not Found ${url}`
+const ERROR_NOT_FOUND_FOLDER = (path) => `Folder Not Found ${path}`
+const ERROR_NOT_DAT_DIRECTORY = (path) => `No Dat information found in ${path}`
+
+module.exports =
+
+class Library {
+  constructor ({ storageLocation, datPort, latest = false }) {
+    this.urls = new Map()
+    this.folders = new Map()
+
+    this.latest = latest
+    this.storageLocation = storageLocation
+    this.folderListLocation = path.join(storageLocation, 'folders.json')
+
+    this.discovery = createDiscovery({
+      port: datPort
+    })
+  }
+
+  replicate (archive) {
+    this.discovery.add(archive)
+  }
+
+  unreplicate (archive) {
+    this.discovery.leave(archive.discoveryKey)
+  }
+
+  async list () {
+    return [...this.urls.keys(), ...this.folders.keys()]
+  }
+
+  get archives () {
+    return [...this.urls.values(), ...this.folders.values()]
+  }
+
+  async get (url) {
+    const entries = [...this.urls.entries(), ...this.folders.entries()]
+
+    for(let [key, archive] of entries) {
+      if(key === url) return archive
+      const archiveURL = 'dat://' + DatEncoding.encode(archive.key)
+      if (archiveURL === url) return archive
+    }
+  }
+
+  async addURL (url) {
+    if (this.urls.has(url)) {
+      const archive = this.urls.get(url)
+      await awaitFN(archive, 'ready')
+      return archive
+    }
+
+    const resolved = `dat://` + await datDns.resolveName(url)
+    const location = this.getURLLocation(resolved)
+    const key = DatEncoding.decode(resolved)
+    const archive = new Hyperdrive(storage(location), key)
+
+    this.urls.set(resolved, archive)
+
+    await this.addArchive(archive)
+
+    return archive
+  }
+
+  async addArchive (archive) {
+    await awaitFN(archive, 'ready')
+
+    this.replicate(archive)
+  }
+
+  async unloadArchive (archive) {
+    this.unreplicate(archive)
+
+    if(archive.mirror) archive.mirror.destroy()
+
+    await awaitFN(archive, 'close')
+  }
+
+  async removeURL (url) {
+    const resolved = `dat://` + await datDns.resolveName(url)
+
+    await this.unloadURL(resolved)
+
+    const location = this.getURLLocation(resolved)
+
+    await fs.remove(location)
+  }
+
+  async unloadURL (url) {
+    const archive = this.urls.get(url)
+    if (!archive) throw new Error(ERROR_NOT_FOUND_URL(url))
+
+    await this.unloadArchive(archive)
+
+    this.urls.delete(url)
+  }
+
+  async addFolder (folder) {
+    if (this.folders.has(folder)) {
+      const archive = this.folders.get(folder)
+      await awaitFN(archive, 'ready')
+      return archive
+    }
+
+    let datPath = null
+    let hasDotDat = false
+
+    if (await fs.pathExists(path.join(folder, 'metadata.key'))) {
+      datPath = folder
+    } else if (await fs.pathExists(path.join(folder, '.dat', 'metadata.key'))) {
+      datPath = path.join(folder, '.dat')
+      hasDotDat = true
+    } else {
+      throw new Error(ERROR_NOT_DAT_DIRECTORY(folder))
+    }
+
+    const archive = new Hyperdrive(storage(datPath))
+
+    this.folders.set(folder, archive)
+
+    await this.addArchive(archive)
+
+    if(!hasDotDat) return archive
+
+    // Based on dat-node importer
+    // https://github.com/datproject/dat-node/blob/master/lib/import-files.js#L9
+    const ignore = datIgnore(folder)
+
+    const mirrorFolder = mirror(folder, { name: '/', fs: archive }, {
+      watch: true,
+      dereference: true,
+      count: true,
+      ignore
+    })
+
+    archive.mirror = mirrorFolder
+
+    return archive
+  }
+
+  async removeFolder (path) {
+    await this.unloadFolder(path)
+
+    await this.saveFolders()
+  }
+
+  async unloadFolder (path) {
+    const archive = this.folders.get(path)
+    if (!archive) throw new Error(ERROR_NOT_FOUND_FOLDER(path))
+
+    await this.unloadArchive(archive)
+
+    this.folders.delete(path)
+  }
+
+  getURLLocation (url) {
+    return path.join(this.storageLocation, url.slice('dat://'.length))
+  }
+
+  async loadURLS () {
+    let stats = []
+    try {
+      stats = await fs.readdir(this.storageLocation, {
+        withFileTypes: true
+      })
+    } catch (e) {
+      // No dats loaded yet
+      return
+    }
+
+    const datFolders = stats.filter((stat) => stat.isDirectory())
+
+    await Promise.all(datFolders.map(({ name }) => {
+      return this.addURL(name)
+    }))
+  }
+
+  async loadFolders () {
+    let folders = []
+    try {
+      folders = await fs.readJSON(this.folderListLocation)
+    } catch (e) {
+      // No folder file present
+    }
+
+    await Promise.all(folders.map((path) => {
+      return this.loadFolder(path)
+    }))
+  }
+
+  async saveFolders () {
+    const folders = this.folders.keys()
+
+    await fs.writeJSON(this.folderListLocation, folders)
+  }
+
+  async load () {
+    await this.loadURLS()
+    await this.loadFolders()
+  }
+
+  async close () {
+    await Promise.all([...this.urls.keys()].map((url) => this.unloadURL(url)))
+    await Promise.all([...this.folders.keys()].map((folder) => this.unloadFolder(folder)))
+
+    this.discovery.close()
+  }
+}
+
+function awaitFN (archive, fnName, ...args) {
+  return new Promise((resolve, reject) => {
+    const fn = archive[fnName]
+    fn.call(archive, ...args, (err) => {
+      if (err) reject(err)
+      else resolve()
+    })
+  })
+}

--- a/library.js
+++ b/library.js
@@ -215,7 +215,7 @@ class Library {
     await Promise.all([...this.urls.keys()].map((url) => this.unloadURL(url)))
     await Promise.all([...this.folders.keys()].map((folder) => this.unloadFolder(folder)))
 
-    this.discovery.close()
+    await this.discovery.close()
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "env-paths": "^2.2.0",
     "fastify": "^2.1.0",
     "fastify-websocket": "^0.3.0",
-    "fs-extra": "^7.0.1",
     "os-service": "^2.1.3",
     "pauls-dat-api": "^8.1.0",
     "read": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
   "homepage": "https://github.com/datproject/dat-store#readme",
   "dependencies": {
     "conf": "^4.0.1",
+    "dat-dns": "^3.2.1",
     "dat-encoding": "^5.0.1",
-    "dat-librarian": "^1.1.4-alpha",
+    "dat-ignore": "^2.1.2",
     "dat-pinning-service-client": "^2.0.2",
     "dat-swarm-defaults": "^1.0.2",
     "debug": "^4.1.1",
@@ -37,8 +38,12 @@
     "fastify": "^2.1.0",
     "fastify-websocket": "^0.3.0",
     "fs-extra": "^7.0.1",
+    "hyperdiscovery": "github:joehand/hyperdiscovery#multiple-cores",
+    "hyperdrive": "^9.14.5",
+    "mirror-folder": "^3.0.0",
     "os-service": "^2.1.3",
     "pauls-dat-api": "^8.1.0",
+    "random-access-file": "^2.1.1",
     "read": "^1.0.7",
     "yargs": "^13.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "fastify": "^2.1.0",
     "fastify-websocket": "^0.3.0",
     "fs-extra": "^7.0.1",
-    "hyperdiscovery": "github:joehand/hyperdiscovery#multiple-cores",
+    "hyperdiscovery": "^9.0.0",
     "hyperdrive": "^9.14.5",
     "mirror-folder": "^3.0.0",
     "os-service": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -26,18 +26,19 @@
   },
   "homepage": "https://github.com/datproject/dat-store#readme",
   "dependencies": {
+    "conf": "^4.0.1",
     "dat-librarian": "^1.1.4-alpha",
     "dat-pinning-service-client": "^2.0.2",
     "dat-swarm-defaults": "^1.0.2",
     "debug": "^4.1.1",
     "discovery-swarm-stream": "^1.1.5",
+    "env-paths": "^2.2.0",
     "fastify": "^2.1.0",
     "fastify-websocket": "^0.3.0",
     "fs-extra": "^7.0.1",
     "os-service": "^2.1.3",
     "pauls-dat-api": "^8.1.0",
     "read": "^1.0.7",
-    "userhome": "^1.0.0",
     "yargs": "^13.2.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/datproject/dat-store#readme",
   "dependencies": {
     "conf": "^4.0.1",
+    "dat-encoding": "^5.0.1",
     "dat-librarian": "^1.1.4-alpha",
     "dat-pinning-service-client": "^2.0.2",
     "dat-swarm-defaults": "^1.0.2",
@@ -35,6 +36,7 @@
     "env-paths": "^2.2.0",
     "fastify": "^2.1.0",
     "fastify-websocket": "^0.3.0",
+    "fs-extra": "^7.0.1",
     "os-service": "^2.1.3",
     "pauls-dat-api": "^8.1.0",
     "read": "^1.0.7",

--- a/server.js
+++ b/server.js
@@ -1,14 +1,14 @@
 const DatLibrarian = require('dat-librarian')
 const createFastify = require('fastify')
 const pda = require('pauls-dat-api')
-const userhome = require('userhome')
 const DSS = require('discovery-swarm-stream/server')
 const DAT_SWARM_DEFAULTS = require('dat-swarm-defaults')
+const envPaths = require('env-paths')
 
 const SWARM_OPTS = DAT_SWARM_DEFAULTS({
   hash: false
 })
-const DEFAULT_STORAGE_LOCATION = userhome('.dat', 'store-data')
+const DEFAULT_STORAGE_LOCATION = envPaths('dat-store').data
 const DEFAULT_PORT = 3472
 const DEFAULT_HOST = '::'
 
@@ -23,12 +23,12 @@ class StoreServer {
     return server
   }
 
-  async init ({ port, host, storageLocation }) {
+  async init ({ port, host, storageLocation, verbose = true }) {
     this.librarian = new DatLibrarian({
       dir: storageLocation || DEFAULT_STORAGE_LOCATION
     })
 
-    this.fastify = createFastify({ logger: true })
+    this.fastify = createFastify({ logger: verbose })
 
     this.dss = new DSS(SWARM_OPTS)
 

--- a/server.js
+++ b/server.js
@@ -26,6 +26,12 @@ class StoreServer {
   async init ({ port, host, storageLocation, verbose = true, datPort }) {
     this.librarian = new DatLibrarian({
       dir: storageLocation || DEFAULT_STORAGE_LOCATION,
+      dat: {
+        // Store all data
+        latest: false,
+        temp: false,
+        live: true,
+      },
       net: {
         port: datPort
       }

--- a/server.js
+++ b/server.js
@@ -108,7 +108,14 @@ class StoreServer {
     this.fastify.post('/v1/dats/add', async ({ body }) => {
       const { url } = body
 
-      await this.librarian.add(url)
+      const { archive } = await this.librarian.add(url)
+
+      await new Promise((resolve, reject) => {
+        archive.ready((err) => {
+          if (err) reject(err)
+          else resolve()
+        })
+      })
 
       return {}
     })

--- a/server.js
+++ b/server.js
@@ -1,9 +1,12 @@
-const DatLibrarian = require('dat-librarian')
 const createFastify = require('fastify')
 const pda = require('pauls-dat-api')
 const DSS = require('discovery-swarm-stream/server')
 const DAT_SWARM_DEFAULTS = require('dat-swarm-defaults')
 const envPaths = require('env-paths')
+const fs = require('fs-extra')
+const path = require('path')
+
+const Library = require('./library')
 
 const SWARM_OPTS = DAT_SWARM_DEFAULTS({
   hash: false
@@ -11,6 +14,8 @@ const SWARM_OPTS = DAT_SWARM_DEFAULTS({
 const DEFAULT_STORAGE_LOCATION = envPaths('dat-store').data
 const DEFAULT_PORT = 3472
 const DEFAULT_HOST = '::'
+
+const ERROR_NOT_LOCAL = (path, ip) => `Cannot Add File Path From Remote IP ${path}, ${ip}`
 
 module.exports =
 
@@ -24,24 +29,20 @@ class StoreServer {
   }
 
   async init ({ port, host, storageLocation, verbose = true, datPort = 3282, latest = false }) {
-    this.librarian = new DatLibrarian({
-      dir: storageLocation || DEFAULT_STORAGE_LOCATION,
-      dat: {
-        // Store all data
-        latest: latest,
-        temp: false,
-        live: true
-      },
-      net: {
-        port: datPort
-      }
+    const dir = storageLocation || DEFAULT_STORAGE_LOCATION
+    this.library = new Library({
+      storageLocation, datPort, latest
     })
+
+    this.dir = dir
 
     this.fastify = createFastify({ logger: verbose })
 
     this.dss = new DSS(SWARM_OPTS)
 
-    await this.librarian.load()
+    await this.library.load()
+
+    await this.loadFolders()
 
     this.initRoutes()
 
@@ -53,6 +54,23 @@ class StoreServer {
       port || DEFAULT_PORT,
       host || DEFAULT_HOST
     )
+  }
+
+  async loadFolders () {
+    const { dir } = this
+    const folderFileLocation = path.join(dir, 'folders.json')
+
+    try {
+      this.folders = await fs.readJSON(folderFileLocation)
+    } catch (e) {
+      this.folders = []
+    }
+
+    await Promise.all(this.folders.map((folder) => this.loadFolder(folder)))
+  }
+
+  async loadFolder (path) {
+
   }
 
   initRoutes () {
@@ -90,7 +108,7 @@ class StoreServer {
     })
 
     this.fastify.get('/v1/dats/', async () => {
-      const keys = await this.librarian.list()
+      const keys = await this.library.list()
 
       const items = []
 
@@ -105,28 +123,29 @@ class StoreServer {
       }
     })
 
-    this.fastify.post('/v1/dats/add', async ({ body }) => {
-      const { url } = body
+    this.fastify.post('/v1/dats/add', async ({ body, ip }) => {
+        const { url } = body
 
-      const { archive } = await this.librarian.add(url)
-
-      await new Promise((resolve, reject) => {
-        archive.ready((err) => {
-          if (err) reject(err)
-          else resolve()
-        })
-      })
-
+        if (url.startsWith('dat://')) {
+          await this.library.addURL(url)
+        } else {
+          if (!ip.endsWith('127.0.0.1')) { throw new Error(ERROR_NOT_LOCAL(url, ip)) }
+          await this.library.addFolder(url)
+        }
       return {}
     })
 
-    this.fastify.post('/v1/dats/remove', async ({ body }) => {
+    this.fastify.post('/v1/dats/remove', async ({ body, ip }) => {
+      try {
       const { url } = body
 
-      // Make sure the dat is fully loaded before removing it
-      await this.librarian.get(url)
-
-      await this.librarian.remove(url)
+      if (url.startsWith('dat://')) {
+        await this.library.removeURL(url)
+      } else {
+        if (!ip.endsWith('127.0.0.1')) { throw new Error(ERROR_NOT_LOCAL(url, ip)) }
+        await this.library.removeFolder(url)
+      }
+    } catch (e) { console.error(e) }
 
       return {}
     })
@@ -143,7 +162,7 @@ class StoreServer {
   }
 
   async getMetadata (key) {
-    const { archive } = await this.librarian.get(key)
+    const archive = await this.library.get(key)
 
     let manifest = {
       name: key
@@ -155,7 +174,7 @@ class StoreServer {
     }
 
     return {
-      url: `dat://${key.toString('hex')}`,
+      url: `dat://${archive.key.toString('hex')}`,
       name: manifest.name,
       title: manifest.title,
       description: manifest.description,
@@ -177,6 +196,6 @@ class StoreServer {
       })
     })
 
-    await this.librarian.close()
+    await this.library.close()
   }
 }

--- a/server.js
+++ b/server.js
@@ -23,9 +23,12 @@ class StoreServer {
     return server
   }
 
-  async init ({ port, host, storageLocation, verbose = true }) {
+  async init ({ port, host, storageLocation, verbose = true, datPort }) {
     this.librarian = new DatLibrarian({
-      dir: storageLocation || DEFAULT_STORAGE_LOCATION
+      dir: storageLocation || DEFAULT_STORAGE_LOCATION,
+      net: {
+        port: datPort
+      }
     })
 
     this.fastify = createFastify({ logger: verbose })

--- a/server.js
+++ b/server.js
@@ -23,14 +23,14 @@ class StoreServer {
     return server
   }
 
-  async init ({ port, host, storageLocation, verbose = true, datPort }) {
+  async init ({ port, host, storageLocation, verbose = true, datPort = 3282, latest = false }) {
     this.librarian = new DatLibrarian({
       dir: storageLocation || DEFAULT_STORAGE_LOCATION,
       dat: {
         // Store all data
-        latest: false,
+        latest: latest,
         temp: false,
-        live: true,
+        live: true
       },
       net: {
         port: datPort

--- a/service.js
+++ b/service.js
@@ -9,7 +9,7 @@ const argv = yargs
   })
   .option('port', {
     describe: 'The port to use for the HTTP API',
-    default: 3282
+    default: 3472
   })
   .option('host', {
     describe: 'The hostname to make the HTTP server listen on'
@@ -20,7 +20,8 @@ const argv = yargs
     type: 'boolean'
   })
   .option('dat-port', {
-    describe: 'The port to listen for P2P connections on'
+    describe: 'The port to listen for P2P connections on',
+    default: 3282
   })
   .option('latest', {
     describe: 'Whether to download just the latest changes',

--- a/service.js
+++ b/service.js
@@ -4,12 +4,27 @@ const yargs = require('yargs')
 
 const argv = yargs
   .command('$0', 'Start the store service')
-  .string('storage-location')
-  .string('dat-port')
-  .string('port')
-  .string('host')
-  .option('verbose',{
+  .option('storage-location', {
+    describe: 'The folder to store dats in'
+  })
+  .option('port', {
+    describe: 'The port to use for the HTTP API',
+    default: 3282
+  })
+  .option('host', {
+    describe: 'The hostname to make the HTTP server listen on'
+  })
+  .option('verbose', {
+    describe: 'Whether the HTTP server should output logs',
     default: true,
+    type: 'boolean'
+  })
+  .option('dat-port', {
+    describe: 'The port to listen for P2P connections on'
+  })
+  .option('latest', {
+    describe: 'Whether to download just the latest changes',
+    default: false,
     type: 'boolean'
   })
   .argv

--- a/service.js
+++ b/service.js
@@ -5,6 +5,13 @@ const yargs = require('yargs')
 const argv = yargs
   .command('$0', 'Start the store service')
   .string('storage-location')
+  .string('dat-port')
+  .string('port')
+  .string('host')
+  .option('verbose',{
+    default: true,
+    type: 'boolean'
+  })
   .argv
 
 const service = require('os-service')

--- a/storage.js
+++ b/storage.js
@@ -1,0 +1,16 @@
+const raf = require('random-access-file')
+const path = require('path')
+
+// Taken from dat-node https://github.com/datproject/dat-node/blob/master/lib/storage.js#L31
+module.exports = (storage) => {
+  return {
+    metadata: function (name, opts) {
+      // I don't think we want this, we may get multiple 'ogd' sources
+      // if (name === 'secret_key') return secretStorage()(path.join(storage, 'metadata.ogd'), {key: opts.key, discoveryKey: opts.discoveryKey})
+      return raf(path.join(storage, 'metadata.' + name))
+    },
+    content: function (name, opts) {
+      return raf(path.join(storage, 'content.' + name))
+    }
+  }
+}

--- a/test.js
+++ b/test.js
@@ -19,7 +19,8 @@ test('Talk to server with client', async (t) => {
     t.pass('Initialized client')
 
     const server = await PinServer.createServer({
-      storageLocation
+      storageLocation,
+      verbose: false
     })
 
     t.pass('Initialized server')

--- a/test.js
+++ b/test.js
@@ -2,8 +2,8 @@ const os = require('os')
 const path = require('path')
 const test = require('tape')
 
-const PinServer = require('./server')
-const PinClient = require('./client')
+const StoreServer = require('./server')
+const StoreClient = require('./client')
 
 const LOCAL_SERVICE = 'http://localhost:3472'
 
@@ -12,13 +12,13 @@ test('Talk to server with client', async (t) => {
     const configLocation = path.join(os.tmpdir(), 'dat-pin-' + Math.random().toString().slice(2, 16))
     const storageLocation = path.join(os.tmpdir(), 'dat-pin-' + Math.random().toString().slice(2, 16))
 
-    const client = new PinClient({
+    const client = new StoreClient({
       configLocation
     })
 
     t.pass('Initialized client')
 
-    const server = await PinServer.createServer({
+    const server = await StoreServer.createServer({
       storageLocation,
       verbose: false
     })
@@ -58,6 +58,24 @@ test('Talk to server with client', async (t) => {
     const [{ url }] = items
 
     t.equals(url, DAT_PROJECT_KEY, 'Archive got added to list')
+
+    const provider = 'example'
+    const providerURL = 'example-service.com'
+
+    const providerClient = new StoreClient({
+      configLocation,
+      provider
+    })
+
+    t.pass('Create a client with provider name')
+
+    await providerClient.setService(providerURL)
+
+    t.pass('Set service with provider')
+
+    const persistedProviderURL = await providerClient.getService()
+
+    t.equals(persistedProviderURL, providerURL, 'Provider service persisted')
 
     await server.destroy()
 

--- a/test.js
+++ b/test.js
@@ -59,6 +59,17 @@ test('Talk to server with client', async (t) => {
 
     t.equals(url, DAT_PROJECT_KEY, 'Archive got added to list')
 
+    const RAW_KEY = DAT_PROJECT_KEY.slice('dat://'.length)
+    const contentPath = path.join(storageLocation, RAW_KEY)
+
+    await client.remove(contentPath)
+
+    t.pass('Removed / Referenced by path')
+
+    const { items: finalItems } = await client.list()
+
+    t.deepEquals(finalItems, [], 'Key got removed')
+
     const provider = 'example'
     const providerURL = 'example-service.com'
 


### PR DESCRIPTION
Addresses a bunch of issues:

- CLI flags for port / host
- CLI flags for storage of config for store client
- CLI flag for port to listen on dat traffic
- Persist all history in store service by default
- Better error message when the store service is unreachable
- Better docs
- Able to have multiple "providers" to handle multiple stores at once
- Able to detect keys in a file path when talking to a remote store
- Able to tell a local store to watch for changes in a local folder