### PR TITLE
Resolve with current manifest if PDA times out

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ Options:
                              to connect                   [string] [default: ""]
   --authentication-password  Require users to use Basic Auth with this password
                              to connect                            [default: ""]
+  --manifest-timeout         set the timeout in milliseconds on reading the PDA 
+                             manifest, defaults to 500 ms
 ```
 
 ## Migrating from 3.0.0 to 4.0.0

--- a/index.js
+++ b/index.js
@@ -47,6 +47,10 @@ const addServiceOptions = (yargs) => yargs
     default: '',
     type: 'password'
   })
+  .option('manifest-timeout', {
+    describe: 'time out if the PDA cannot be read with timeout milliseconds',
+    default: 500
+  })
 const addClientOptions = (yargs) => yargs
   .option('config-location')
 const noOptions = () => void 0

--- a/server.js
+++ b/server.js
@@ -219,7 +219,7 @@ class StoreServer {
       // give Paul's Dat API a moment to resolve and win the race
       // otherwsie, just return the resolved manifest you've already got
       manifest = Promise.race([
-        await pda.readManifest(archive),
+        pda.readManifest(archive),
         new Promise((resolve, reject) => setTimeout(() => resolve(manifest), 500))
       ])
       

--- a/server.js
+++ b/server.js
@@ -36,7 +36,8 @@ class StoreServer {
     allowCors = false,
     exposeToInternet = false,
     authenticationUsername = '',
-    authenticationPassword = ''
+    authenticationPassword = '',
+    manifestTimeout
   }) {
     storageLocation = storageLocation || DEFAULT_STORAGE_LOCATION
 
@@ -48,6 +49,7 @@ class StoreServer {
 
     this.authenticationUsername = authenticationUsername
     this.authenticationPassword = authenticationPassword
+    this.manifestTimeout = manifestTimeout
 
     this.fastify = createFastify({ logger: verbose })
 
@@ -215,14 +217,11 @@ class StoreServer {
     }
     try {
       
-      // https://javascript.info/promise-api#promise-race
-      // give Paul's Dat API a moment to resolve and win the race
-      // otherwsie, just return the resolved manifest you've already got
       manifest = Promise.race([
-        pda.readManifest(archive),
-        new Promise((resolve, reject) => setTimeout(() => resolve(manifest), 500))
+        await pda.readManifest(archive),
+        delay(manifestTimeout).then(() => manifest) 
       ])
-      
+
     } catch (e) {
       // It must not have a manifest, that's okay
     }

--- a/server.js
+++ b/server.js
@@ -214,7 +214,15 @@ class StoreServer {
       name: key
     }
     try {
-      manifest = await pda.readManifest(archive)
+      
+      // https://javascript.info/promise-api#promise-race
+      // give Paul's Dat API a moment to resolve and win the race
+      // otherwsie, just return the resolved manifest you've already got
+      manifest = Promise.race([
+        await pda.readManifest(archive),
+        new Promise((resolve, reject) => setTimeout(() => resolve(manifest), 500))
+      ])
+      
     } catch (e) {
       // It must not have a manifest, that's okay
     }

--- a/service.js
+++ b/service.js
@@ -48,6 +48,10 @@ const argv = yargs
     default: '',
     type: 'password'
   })
+  .option('manifest-timeout', {
+    describe: 'time out if the PDA cannot be read with timeout milliseconds',
+    default: 500
+  })
   .argv
 
 const service = require('os-service')


### PR DESCRIPTION
I think this should work to timeout the manifest read? Is 500 ms too long for something in memory? Maybe it should be shorter? I don't have any read on how long it takes to read, so just erroring on the safe side.

Seems to work ok, but `dat-store list` still isn't outputing the list, I'll continue to troubleshoot it