### PR TITLE
A new script for creating a SystemD service

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,10 @@ The fastify server will take care of the rest of your serving needs for the stor
 #### Linux (SystemD)
 
 ```bash
-# This will create the service file
-sudo cat << EOF > /etc/systemd/system/dat-store.service
+# Paste this into an interactive bash or zsh shell, or save it as a file and run it with sh.
+
+# This will create the service file.
+sudo cat << EOF | sudo tee /etc/systemd/system/dat-store.service > /dev/null
 [Unit]
 Description=Dat storage provider, keeps dats alive in the background.
 
@@ -115,7 +117,7 @@ Description=Dat storage provider, keeps dats alive in the background.
 Type=simple
 # Check that dat-store is present at this location
 # If it's not, replace the path with its location
-ExecStart=/usr/bin/dat-store run-service
+ExecStart=`which dat-store` run-service
 Restart=always
 
 [Install]


### PR DESCRIPTION
Introducing: A script for adding dat-store to SystemD, that works.

`sudo cat << EOF > /etc/systemd/system/dat-store.service` fails with `zsh: permission denied: /etc/systemd/system/dat-store.service` on my machine.

I've tested this modified script on bash, zsh, and sh and it works quite well (unless I paste it directly into an interactive sh terminal, then it fails to parse `which dat-store`.). I also made it so that you don't have to specify the location of dat-store manually.