### PR TITLE
Add DNS TXT record resolution in gateway

### DIFF
--- a/library.js
+++ b/library.js
@@ -64,6 +64,10 @@ class Library {
     return [...this.urls.values(), ...this.folders.values()]
   }
 
+  async resolve (url) {
+    return await this.resolveName(url)
+  }
+
   async get (url) {
     const entries = [...this.urls.entries(), ...this.folders.entries()]
 

--- a/server.js
+++ b/server.js
@@ -48,17 +48,6 @@ class StoreServer {
 
     this.dir = storageLocation
     
-    const SDK = require('dat-sdk')
-    const sdk = await SDK({
-      storage: storageLocation,
-      swarmOpts: {
-        ephemeral: false,
-        preferredPort: p2pPort
-      }
-    })
-    const {resolveName} = sdk
-    this.resolveName = resolveName
-
     this.authenticationUsername = authenticationUsername
     this.authenticationPassword = authenticationPassword
     this.manifestTimeout = manifestTimeout
@@ -211,7 +200,7 @@ class StoreServer {
     })
 
     this.fastify.get('/gateway/:key/*', fastifyHyperdrive(async (raw) => {
-      const resolved = await this.resolveName(raw)
+      const resolved = await this.library.resolve(raw)
       const key = Buffer.from(resolved, 'hex')
       const url = `hyper://${key.toString('hex')}`
 

--- a/server.js
+++ b/server.js
@@ -47,6 +47,17 @@ class StoreServer {
     })
 
     this.dir = storageLocation
+    
+    const SDK = require('dat-sdk')
+    const sdk = await SDK({
+      storage: storageLocation,
+      swarmOpts: {
+        ephemeral: false,
+        preferredPort: p2pPort
+      }
+    })
+    const {resolveName} = sdk
+    this.resolveName = resolveName
 
     this.authenticationUsername = authenticationUsername
     this.authenticationPassword = authenticationPassword
@@ -200,7 +211,8 @@ class StoreServer {
     })
 
     this.fastify.get('/gateway/:key/*', fastifyHyperdrive(async (raw) => {
-      const key = Buffer.from(raw, 'hex')
+      const resolved = await this.resolveName(raw)
+      const key = Buffer.from(resolved, 'hex')
       const url = `hyper://${key.toString('hex')}`
 
       const archive = await this.library.get(url)


### PR DESCRIPTION
This PR is about https://github.com/hyphacoop/distributed-press-organizing/issues/25#issuecomment-749151748 in converation with @RangerMauve but I am not familiar with the codebase and even though this allows my HTTP gateway to resolve https://hyper.distributed.press/gateway/api.staging.compost.digital/ now, ~~my approach (adding SDK to server.js) may not be the right thing to do.~~ _(edit: oh yea that was a bad idea, I moved the `resolve` in as a library function now.)_